### PR TITLE
Personalization edits

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -4,12 +4,12 @@ languageCode = "en-us"
 title = "Matt McNaughton's Blog"
 theme = "hugo-cactus-theme"
 # Disable comments by leaving disqusShortname empty
-disqusShortname = ""
+disqusShortname = "mattjmcnaughton"
 
 [params]
   name = "Matt McNaughton"
   description = "My Blog"
-  bio = ""
+  bio = "Programmer - Cook - Mental Health Advocate"
   # Enter optionally your twitter account
   twitter = "mattjmcnaughton"
   enableRSS = true


### PR DESCRIPTION
Fix #3

Update blog with relevant personalization links. The strangest piece of
the puzzle is figuring out how to add an avatar. The `hugo-cactus-theme`
requires the `avatar.png` file to be added to its static images, which
requires me to make an update and commit within
`themes/hugo-cactus-theme`. Which is a little weird, but not the end of
the world.

Signed-off-by: mattjmcnaughton <mattjmcnaughton@gmail.com>