### PR TITLE
Decrease sdep version

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,7 @@ install: go get -v github.com/spf13/hugo
 sudo: required
 script:
 - hugo -v
-- sudo pip install sdep>=0.21
+- sudo pip install sdep>=0.1.0
 - sdep update
 branches:
   only:


### PR DESCRIPTION
This [pr](https://github.com/mattjmcnaughton/sdep/pull/39) for sdep
reset the version number now that the project is following `semver`. So
update the version we require correspondingly.

Signed-off-by: mattjmcnaughton <mattjmcnaughton@gmail.com>