### PR TITLE
Fix Hugo Build error

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,8 @@
 language: go
-install: go get -v github.com/spf13/hugo
+install:
+  - go get -u -v github.com/kardianos/govendor
+  - go get -u -v github.com/spf13/hugo
+  - cd $GOPATH/src/github.com/spf13/hugo && govendor sync && go install
 sudo: required
 script:
 - hugo -v


### PR DESCRIPTION
Fix an error where the `hugo -v` step which builds the static site was
failing. The failure appears to be because of upstream hugo
dependencies, so explicitly install the dependencies with `govendor`.

Signed-off-by: mattjmcnaughton <mattjmcnaughton@gmail.com>