### PR TITLE
Fix travis build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,12 +1,14 @@
-language: go
+language: python
 sudo: required
-before_install:
-  - sudo apt-get -qq update
-  - sudo apt-get install -y hugo
+# It is not possible to install `hugo` with `apt-get` until 16.04, which travis
+# doesn't support yet.
+install:
+  - wget -O /tmp/hugo.deb https://github.com/spf13/hugo/releases/download/v0.23/hugo_0.23_Linux-64bit.deb
+  - sudo dpkg -i /tmp/hugo.deb
 script:
 - cd $TRAVIS_BUILD_DIR
+- sudo pip install sdep>=0.1.0 Pygments
 - hugo -v
-- sudo pip install sdep>=0.1.0
 - sdep update
 branches:
   only:


### PR DESCRIPTION
The `hugo` package isn't available through `apt`
until Ubuntu 16.04, which travis doesn't offer.
Instead, we build it by downloading the `.deb` and
building it with `dpkg`.