### PR TITLE
Convert blog to using Caddy w/ prom. plugin

### DIFF
--- a/Caddyfile
+++ b/Caddyfile
@@ -1,0 +1,7 @@
+localhost:80
+tls off
+prometheus {
+  use_caddy_addr
+}
+log stdout
+errors stdout

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,2 +1,4 @@
-FROM nginx:alpine
-COPY public /usr/share/nginx/html
+FROM mattjmcnaughton/local-caddy-prometheus-base:latest
+
+COPY public /srv
+COPY Caddyfile /etc/Caddyfile

--- a/Makefile
+++ b/Makefile
@@ -1,13 +1,19 @@
 # Makefile for running development and production blog commands.
 
-IMAGE = "mattjmcnaughton/blog:$$(git rev-list HEAD -n 1)"
+GIT_HEAD = "$$(git rev-list HEAD -n 1)"
+
+BASE_IMAGE = "mattjmcnaughton/local-caddy-prometheus-base:latest"
+IMAGE = "mattjmcnaughton/blog:$(GIT_HEAD)"
 
 # Instruct hugo to build our website. All of the built contents of the website
 # go into `./public`.
 build:
 	hugo
 
-build_image: build
+build_base_image:
+	docker build --build-arg plugins=prometheus -t $(BASE_IMAGE) github.com/abiosoft/caddy-docker.git
+
+build_image: build build_base_image
 	docker build -t $(IMAGE) .
 
 # @TODO(mattjmcnaughton) Automate this as part of a CI/CD pipeline.


### PR DESCRIPTION
Previously, we were serving our static blog via nginx. However, nginx
did not have great out of the box prometheus support. Caddy, on the
other hand, has great support for prometheus via a
[plugin](https://caddyserver.com/docs/http.prometheus). So convert our
blog to serve via Caddy using
[caddy-docker](https://github.com/abiosoft/caddy-docker).

Because we still serve via port 80, and do not use any of Caddy's TLS
management (because we'll configure SSL at the Kubernetes layer I
think), we should not need to update our Kubernetes configuration at
all.

There may be a way to build the `caddy-docker` image with the prometheus
plugin as part of a multi-stage Docker build. Exploring that later could
allow us to remove the `build_base_image` make target.