### PR TITLE
Update Dockerfile to manually install Caddy

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,50 @@
-FROM mattjmcnaughton/local-caddy-prometheus-base:latest
+# This Dockerfile builds the image from which we run a container to serve my
+# static blog. We utilize a multi-stage build to download two separate binaries
+# in an isolated environment, before using a distroless base image for the final
+# image which contains just our binaries, configuration, and static content to
+# serve. Using the distroless base image with minimal dependencies ensures we
+# have the smallest possible image, which is useful with respect to storage and
+# minimizing attack surface.
 
-COPY public /srv
+# Based on https://github.com/abiosoft/caddy-docker/blob/master/builder/Dockerfile
+FROM golang:1.10-alpine as parent_builder
+
+# Necessary for `go get ...`
+RUN apk add --no-cache git gcc musl-dev
+# We use this tool as it is also used in
+# https://github.com/abiosoft/caddy-docker/blob/master/Dockerfile.
+# @TODO(mattjmcnaughton) Are there any disadvantages to just running `caddy`
+# directly?
+RUN go get -v github.com/abiosoft/parent
+
+# Use a "fuller" base image so the bash script we're executing does not have any
+# missing dependencies. As this is a multi-stage build, there is no penalty for
+# utilizing a larger base image for an intermediary step.
+FROM ubuntu:18.04 as caddy_builder
+
+# Ensure we install gnupg as the bash script will use it to validate our
+# install.
+RUN apt update && apt install curl gnupg -y
+
+# Follow instructions from https://caddyserver.com/download
+RUN curl https://getcaddy.com | bash -s personal http.prometheus
+
+# Validate Caddy working as expected
+RUN /usr/local/bin/caddy -version
+RUN /usr/local/bin/caddy -plugins
+
+# Use the smallest possible base image
+FROM gcr.io/distroless/base
+
+WORKDIR /srv
+EXPOSE 80
+
+# Copy binaries from the previous states in our multi-stage build.
+COPY --from=parent_builder /go/bin/parent /bin/parent
+COPY --from=caddy_builder /usr/local/bin/caddy /bin/caddy
+
 COPY Caddyfile /etc/Caddyfile
+COPY public /srv
+
+ENTRYPOINT ["/bin/parent", "/bin/caddy"]
+CMD ["--conf", "/etc/Caddyfile", "--log", "stdout", "--agree=false"]

--- a/Makefile
+++ b/Makefile
@@ -1,8 +1,6 @@
 # Makefile for running development and production blog commands.
 
 GIT_HEAD = "$$(git rev-list HEAD -n 1)"
-
-BASE_IMAGE = "mattjmcnaughton/local-caddy-prometheus-base:latest"
 IMAGE = "mattjmcnaughton/blog:$(GIT_HEAD)"
 
 # Instruct hugo to build our website. All of the built contents of the website
@@ -10,10 +8,7 @@ IMAGE = "mattjmcnaughton/blog:$(GIT_HEAD)"
 build:
 	hugo
 
-build_base_image:
-	docker build --build-arg plugins=prometheus -t $(BASE_IMAGE) github.com/abiosoft/caddy-docker.git
-
-build_image: build build_base_image
+build_image: build
 	docker build -t $(IMAGE) .
 
 # @TODO(mattjmcnaughton) Automate this as part of a CI/CD pipeline.


### PR DESCRIPTION
Previously, we first built a specific
[caddy-docker](https://github.com/abiosoft/caddy-docker) image with our
given plugins via a Make step, and then used said image as the base of
our image. I feel having to do a separate step in Make was a bit of a
smell.

Refactor to perform a multi-stage Docker build, in which we install
Caddy with the necessary plugins in the first stage, and then copy the
binary over to the final stage, along with our static assets and
configuration files. The multi-stage build process has the added
advantage of allowing us to use a distroless build, which decreases
image size and attack surface.

We verify its working via `docker run -p 8080:80
mattjmcnaughton:blog:...`.